### PR TITLE
Fix typo in jquery package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "typescript": "3.8.3"
   },
   "peerDependencies": {
-    "jQuery": "3.5.1"
+    "jquery": "3.5.1"
   },
   "scripts": {
     "prepack": "yarn build",


### PR DESCRIPTION
For whatever reason newer NPM versions fail to resolve dependency tree when `Q` is capital in `jQuery` for initial install

But once you have project installed already, then it resolves all good. Seems to be some bug in NPM: https://github.com/npm/cli/issues/5096

```
└─$ npm i
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: frontend-vue@0.1.0
npm ERR! Found: jquery@3.5.1
npm ERR! node_modules/jquery
npm ERR!   jquery@"3.5.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer jQuery@"3.5.1" from jquery-expression-builder@0.1.2
npm ERR! node_modules/jquery-expression-builder
npm ERR!   jquery-expression-builder@"^0.1.2" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /home/mcsneaky/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/mcsneaky/.npm/_logs/2022-06-28T23_06_36_648Z-debug-0.log
```